### PR TITLE
Properly parse the Link header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ gem 'nokogiri'
 gem 'thin'
 gem 'rack-ssl'
 gem 'rack-flash3', require: 'rack-flash'
+gem 'link_header'
+gem 'activesupport', '~> 4.2'
 
 group :development do
   gem 'shotgun'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,23 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (4.2.0)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
     daemons (1.1.9)
     dotenv (1.0.2)
     eventmachine (1.0.5)
     httparty (0.13.3)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
+    i18n (0.7.0)
     json (1.8.2)
+    link_header (0.0.8)
     mini_portile (0.6.2)
+    minitest (5.5.1)
     multi_xml (0.5.5)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
@@ -29,14 +38,19 @@ GEM
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0)
       rack (~> 1.0)
+    thread_safe (0.3.4)
     tilt (1.4.1)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (~> 4.2)
   dotenv
   httparty
+  link_header
   nokogiri
   rack-flash3
   rack-ssl

--- a/lib/micropublish.rb
+++ b/lib/micropublish.rb
@@ -1,6 +1,7 @@
 require_relative 'micropublish/auth'
 require_relative 'micropublish/micropub'
 require_relative 'micropublish/server'
+require 'active_support/core_ext/object/try'
 
 module Micropublish
 end

--- a/lib/micropublish/auth.rb
+++ b/lib/micropublish/auth.rb
@@ -40,7 +40,10 @@ module Micropublish
 
         # check http header for endpoints
         if response.headers.key?('Link')
-          endpoints[:micropub_endpoint] = micropub_endpoint_from_header(response.headers['Link'])
+          links = LinkHeader.parse(response.headers['Link'])
+          endpoints[:micropub_endpoint] = links.find_link(['rel', 'micropub']).try(:href)
+          endpoints[:token_endpoint] = links.find_link(['rel', 'token_endpoint']).try(:href)
+          endpoints[:authorization_endpoint] = links.find_link(['rel', 'authorization_endpoint']).try(:href)
         end
 
         # check html head for endpoints
@@ -118,16 +121,6 @@ module Micropublish
         uri = URI.parse(u)
         uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
       rescue URI::InvalidURIError
-      end
-    end
-    
-    # adapted from 
-    # https://github.com/indieweb/mention-client-ruby/blob/master/lib/webmention/client.rb#L143
-    def micropub_endpoint_from_header(link)
-      if matches = link.match(%r{<(https?://[^>]+)>; rel="micropub"})
-        matches[1]
-      elsif matches = link.match(%r{rel="micropub"; <(https?://[^>]+)>})
-        matches[1]
       end
     end
 


### PR DESCRIPTION
You were only reading the `micropub` link, not the token/authorization endpoints for some reason...

(The activesupport dependency is for the excellent `Object#try` method)