### PR TITLE
Small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 .env
+.bundle
+vendor/bundle

--- a/lib/micropublish/auth.rb
+++ b/lib/micropublish/auth.rb
@@ -35,7 +35,7 @@ module Micropublish
     def find_endpoints(me)
       response = HTTParty.get(me)
 
-      if response.code == 200
+      if (200...300).include? response.code
         endpoints = {}
 
         # check http header for endpoints
@@ -80,7 +80,7 @@ module Micropublish
           scope: 'post',
           redirect_uri: redirect_uri
         })
-      if response.code == 200
+      if (200...300).include? response.code
         puts "callback=#{response.body}"
         response_hash = CGI.parse(response.parsed_response)
         if response_hash['me'].first == me
@@ -103,7 +103,7 @@ module Micropublish
           state: state,
           scope: 'post'
         })
-      if response.code == 200
+      if (200...300).include? response.code
         response_hash = CGI.parse(response.parsed_response)
         puts "token response_hash=#{response_hash.inspect}"
         response_hash['access_token'].first

--- a/lib/micropublish/micropub.rb
+++ b/lib/micropublish/micropub.rb
@@ -35,8 +35,10 @@ module Micropublish
       puts "syndicate-to response=#{response.inspect}"
       return unless response.code == 200
       response_hash = CGI.parse(response.parsed_response)
-      return unless response_hash.key?('syndicate-to')
-      response_hash['syndicate-to'].first.split(',')
+      if response_hash.key?('syndicate-to')
+        return response_hash['syndicate-to'].first.split(',')
+      end
+      response_hash['syndicate-to[]']
     end
 
     def syndication_label(syndication)
@@ -55,7 +57,7 @@ module Micropublish
         url.split('/')[3]
       end
     end
-    
+
     def post_types
       {
         note:     { label: 'Note', icon: 'comment', fields: %i(content) },

--- a/lib/micropublish/server.rb
+++ b/lib/micropublish/server.rb
@@ -56,7 +56,7 @@ module Micropublish
                                           session[:state],
                                           "#{request.base_url}/auth/callback",
                                           client_id)
-      logout!("No endpoints were found at #{me}. Please check your site is Micropub-compliant.") if endpoints_and_token.nil?
+      logout!("No endpoints were found at #{params[:me]}. Please check your site is Micropub-compliant.") if endpoints_and_token.nil?
       # login and token grant was successful so store in session
       session.merge!(endpoints_and_token)
       redirect :new


### PR DESCRIPTION
- There was a bug in the "No endpoints found" error message: `me` doesn't exist, only `params[:me]`
- There are different success codes, not just 200... for example, my token endpoint returns 201 Created (a token was created!)
- The `syndicate-to` query response format was updated – the wiki now has the following example: `syndicate-to[]=https://twitter.com/aaronpk&syndicate-to[]=https://twitter.com/pkbot&syndicate-to[]=https://facebook.com/aaronpk`