### PR TITLE
fix syndicate-to html escaping

### DIFF
--- a/views/new.erb
+++ b/views/new.erb
@@ -90,8 +90,8 @@
       <% syndicate_to.each do |syndication| %>
         <% unless syndication.is_a?(String) %>
           <label class="checkbox-inline">
-            <input type="checkbox" name="syndicate_to" value="<%= syndication['uid'] %>">
-            <%= syndication['name'] %>
+            <input type="checkbox" name="syndicate_to" value="<%= h syndication['uid'] %>">
+            <%= h syndication['name'] %>
           </label>
         <% end %>
       <% end %>


### PR DESCRIPTION
In [the new Micropub syndication targets format](http://micropub.net/draft/#syndication-targets), the `uid` field can be literally anything:

> The uid property is opaque to the client, and is the value the client sends in the Micropub request to indicate the targets to syndicate to.

You can't trust it to *not* be HTML… I do use HTML there!

I'm surprised you made this mistake since you have a lot of things escaped in the same template.