### PR TITLE
add response_type=code to request an access token that can create posts

### DIFF
--- a/lib/micropublish/server.rb
+++ b/lib/micropublish/server.rb
@@ -69,7 +69,8 @@ module Micropublish
         client_id: request.base_url,
         state: session[:state],
         scope: session[:scope],
-        redirect_uri: "#{request.base_url}/auth/callback"
+        redirect_uri: "#{request.base_url}/auth/callback",
+        response_type: "code"
       })
       redirect "#{endpoints[:authorization_endpoint]}?#{query}"
     end


### PR DESCRIPTION
`response_type=code` is needed to indicate to the authorization server that this is a request for an authorization code rather than just a sign-in attempt