### PR TITLE
Use subtype presets when editing to match creates.

### DIFF
--- a/config/properties.json
+++ b/config/properties.json
@@ -7,8 +7,7 @@
     "rsvp",
     "name",
     "content",
-    "content-html",
-		"summary",
+    "summary",
     "published",
     "category",
     "mp-syndicate-to",
@@ -25,14 +24,14 @@
 			"note": {
 				"name": "Note",
 				"icon": "comment",
-				"properties": ["content", "location", "location-name"],
+				"properties": ["content"],
 				"required": ["content"]
 			},
 			"article": {
 				"name": "Article",
 				"icon": "file-text",
-				"properties": ["name", "content-html"],
-				"required": ["name", "content-html"]
+				"properties": ["name", "content"],
+				"required": ["name", "content"]
 			},
 			"rsvp": {
 				"name": "RSVP",

--- a/lib/micropublish/micropub.rb
+++ b/lib/micropublish/micropub.rb
@@ -15,12 +15,23 @@ module Micropublish
       end
     end
 
-    def source(url)
+    def source_all(url)
+      body = get_source(url)
+      Post.new(body['type'], body['properties'])
+    end
+
+    def source_properties(url, properties)
+      body = get_source(url, properties)
+      # assume h-entry
+      Post.new(['h-entry'], body['properties'])
+    end
+
+    def get_source(url, properties=nil)
       validate_url!(url)
       query = { q: 'source', url: url }
+      query[:properties] = properties if properties
       response = HTTParty.get(@micropub, query: query, headers: headers)
-      body = JSON.parse(response.body)
-      Post.new(body['type'], body['properties'])
+      JSON.parse(response.body)
     end
 
     def validate_url!(url)

--- a/lib/micropublish/version.rb
+++ b/lib/micropublish/version.rb
@@ -1,5 +1,5 @@
 module Micropublish
 
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 
 end

--- a/spec/micropublish/compare_spec.rb
+++ b/spec/micropublish/compare_spec.rb
@@ -18,7 +18,6 @@ describe Micropublish::Compare do
         "rsvp",
         "name",
         "content",
-        "content-html",
         "published",
         "category",
         "mp-syndicate-to",

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -1,6 +1,6 @@
 <div class="panel panel-default">
   <div class="panel-heading">
-    <h3 class="panel-title">Create a new post (h-entry)</h3>
+    <h3 class="panel-title">Create a new post</h3>
   </div>
   <div class="panel-body new-buttons">
     <div>
@@ -47,6 +47,9 @@
     </div>
     <div class="panel-footer">
       <button name="edit" class="btn btn-default">Edit</button>
+      &nbsp;
+      <button name="edit-all" class="btn btn-default"
+        title="&quot;The Kitchen Sink&quot; editor">Edit all fields</button>
       &nbsp;
       <div class="btn-group" role="group">
         <button name="delete" class="btn btn-default">Delete</button>

--- a/views/form.erb
+++ b/views/form.erb
@@ -1,17 +1,18 @@
 <form action="<%= @action_url %>" method="post" class="helpable" id="form">
   <input type="hidden" name="_type" value="<%= @type %>">
   <input type="hidden" name="_subtype" value="<%= @subtype %>">
+  <% if @all %><input type="hidden" name="_all" value=""><% end %>
 
   <div class="panel panel-default">
 
     <div class="panel-heading">
       <h3 class="panel-title">
-        <% if @action_label == 'Create' %>
-          New <%= @subtype_label %>
+        <% if @all %>
+          All fields
         <% else %>
-          Edit post
+          <span class="fa fa-<%= @subtype_icon %>"></span>
         <% end %>
-        (<%= @type %>)
+        <%= @subtype_label || "" %>
       </h3>
     </div>
 
@@ -140,7 +141,7 @@
         </div>
       <% end %>
 
-      <% if (@all && @post.properties.key?('content') && !@post.properties['content'][0].is_a?(Hash)) || @properties.include?('content') %>
+      <% if (@edit && @post.properties.key?('content') && !@post.properties['content'][0].is_a?(Hash)) || (@properties.include?('content') && @subtype != 'article') %>
         <div class="form-group">
           <label for="content">
             Content
@@ -159,14 +160,12 @@
           </p>
         </div>
         <%= autogrow_script('content') %>
-      <% end %>
-
-      <% if (@all && @post.properties.key?('content') && @post.properties['content'][0].is_a?(Hash)) || @properties.include?('content-html') %>
+      <% elsif (@edit && @post.properties.key?('content') && @post.properties['content'][0].is_a?(Hash)) || (@properties.include?('content') && @subtype == 'article') %>
         <% content_html_value = @post.properties.key?('content') && @post.properties['content'][0].is_a?(Hash) && @post.properties['content'][0].key?('html') ? h(@post.properties['content'][0]['html']) : "" %>
         <div class="form-group">
           <label>
             Content (HTML)
-            <% if @required.include?('content-html') %><span class="required" title="required">*</span><% end %>
+            <% if @required.include?('content') %><span class="required" title="required">*</span><% end %>
           </label>
           <textarea id="content-html" class="form-control" rows="5" name="content[][html]"><%= content_html_value %></textarea>
           <trix-editor input="content-html" style="display: none;"></trix-editor>
@@ -196,25 +195,6 @@
           </p>
         </div>
         <%= autogrow_script('summary') %>
-      <% end %>
-
-      <% if @all || @properties.include?('published') %>
-        <div class="form-group">
-          <label for="published">
-            Published
-            <% if @required.include?('published') %><span class="required" title="required">*</span><% end %>
-          </label>
-          <input type="datetime" class="form-control" id="published" name="published"
-            <% if @required.include?('published') %>required<% end %>
-            value="<%= h @post.properties['published'][0] if @post.properties.key?('published') %>">
-          <p class="help-block">
-            Enter a datetime for when this post was (or will be) published.
-            The suggested format is YYYY-MM-DDTHH:MM:SSZ,
-            e.g. 2016-11-21T12:34:56Z for a post at 12:34:56 UTC on 21 November
-            2016.
-            <code>published</code>
-          </p>
-        </div>
       <% end %>
 
       <% if @all || @properties.include?('category') %>
@@ -260,7 +240,25 @@
         </div>
       <% end %>
 
-      <% if @all || @properties.include?('syndication') %>
+      <% if !@edit && @properties.include?('mp-slug') %>
+        <div class="form-group">
+          <label>
+            Slug
+            <% if @required.include?('mp-slug') %><span class="required" title="required">*</span><% end %>
+          </label>
+          <input type="text" class="form-control" id="mp-slug" name="mp-slug"
+            <% if @required.include?('mp-slug') %>required<% end %>
+            value="<%= h @post.properties['mp-slug'][0] if @post.properties.key?('mp-slug') %>">
+          <p class="help-block">
+            Enter a short slug you would like your server to use (if supported).
+            <code>mp-slug</code>
+          </p>
+        </div>
+      <% end %>
+
+      <% if @edit %><hr><% end %>
+
+      <% if @all || @edit || @properties.include?('syndication') %>
         <div class="form-group">
           <label>
             Syndication
@@ -278,18 +276,21 @@
         <%= autogrow_script('syndication') %>
       <% end %>
 
-      <% if @properties.include?('mp-slug') %>
+      <% if @all || @edit || @properties.include?('published') %>
         <div class="form-group">
-          <label>
-            Slug
-            <% if @required.include?('mp-slug') %><span class="required" title="required">*</span><% end %>
+          <label for="published">
+            Published
+            <% if @required.include?('published') %><span class="required" title="required">*</span><% end %>
           </label>
-          <input type="text" class="form-control" id="mp-slug" name="mp-slug"
-            <% if @required.include?('mp-slug') %>required<% end %>
-            value="<%= h @post.properties['mp-slug'][0] if @post.properties.key?('mp-slug') %>">
+          <input type="datetime" class="form-control" id="published" name="published"
+            <% if @required.include?('published') %>required<% end %>
+            value="<%= h @post.properties['published'][0] if @post.properties.key?('published') %>">
           <p class="help-block">
-            Enter a short slug you would like your server to use (if supported).
-            <code>mp-slug</code>
+            Enter a datetime for when this post was (or will be) published.
+            The suggested format is YYYY-MM-DDTHH:MM:SSZ,
+            e.g. 2016-11-21T12:34:56Z for a post at 12:34:56 UTC on 21 November
+            2016.
+            <code>published</code>
           </p>
         </div>
       <% end %>


### PR DESCRIPTION
- Add new “Edit all fields” button as fallback.
- Use selected properties when querying source.
- Use subtype icon in form title.
- Remove unused location/location-name properties from config.
- Increments version to 2.1.0.