### PR TITLE
Add toggle for text or HTML content in articles

### DIFF
--- a/lib/micropublish/post.rb
+++ b/lib/micropublish/post.rb
@@ -11,7 +11,8 @@ module Micropublish
     def self.properties_from_params(params)
       props = {}
       params.keys.each do |param|
-        next if params[param].empty? || params[param] == [""]
+        next if params[param].nil? || params[param].empty? ||
+          params[param] == [""]
         if param.start_with?('_')
           next
         elsif param == 'mp-syndicate-to'

--- a/views/form.erb
+++ b/views/form.erb
@@ -188,7 +188,7 @@
         </div>
       <% end %>
 
-      <% if @properties.include?('content') %>
+      <% if @all || @properties.include?('content') %>
         <div class="form-group">
           <label for="content">
             Content

--- a/views/form.erb
+++ b/views/form.erb
@@ -188,42 +188,41 @@
         </div>
       <% end %>
 
-      <% if (@edit && @post.properties.key?('content') && !@post.properties['content'][0].is_a?(Hash)) || (@properties.include?('content') && @subtype != 'article') %>
+      <% if @properties.include?('content') %>
         <div class="form-group">
           <label for="content">
             Content
             <% if @required.include?('content') %><span class="required" title="required">*</span><% end %>
           </label>
-          <div style="float: right;">
-            <span class="badge" id="content_count"></span>
-          </div>
-          <textarea class="form-control" rows="5" name="content" id="content"
-            <% if @required.include?('content') %>required<% end %>
-            ><%= h @post.properties['content'][0] if @post.properties.key?('content') %></textarea>
-          <p class="help-block">
-            Enter content for this post.
-            You should use plain text or markup if your server supports this.
-            <code>content</code>
-          </p>
-        </div>
-        <%= autogrow_script('content') %>
-      <% elsif (@edit && @post.properties.key?('content') && @post.properties['content'][0].is_a?(Hash)) || (@properties.include?('content') && @subtype == 'article') %>
-        <% content_html_value = @post.properties.key?('content') && @post.properties['content'][0].is_a?(Hash) && @post.properties['content'][0].key?('html') ? h(@post.properties['content'][0]['html']) : "" %>
-        <div class="form-group">
-          <label>
-            Content (HTML)
-            <% if @required.include?('content') %><span class="required" title="required">*</span><% end %>
-          </label>
-          <textarea id="content-html" class="form-control" rows="5" name="content[][html]"><%= content_html_value %></textarea>
-          <trix-editor input="content-html" style="display: none;"></trix-editor>
-          <p class="help-block">
-            Enter content for this post.
-            You may use rich content via the embedded
-            <a href="https://trix-editor.org">Trix</a> editor or, if your
-            browser does not have JavaScript enabled, you can directly enter
-            HTML.
-            <code>content[][html]</code>
-          </p>
+          &nbsp;
+          <% if (@edit && @post.properties.key?('content') && !@post.properties['content'][0].is_a?(Hash)) || (@properties.include?('content') && @subtype != 'article') || (@properties.include?('content') && params.key?('text')) %>
+            <% if @subtype == 'article' %><a href="<%= request.url.sub(/\?text$/, '') %>">Switch to HTML</a><% end %>
+            <div style="float: right;">
+              <span class="badge" id="content_count"></span>
+            </div>
+            <textarea class="form-control" rows="5" name="content" id="content"
+              <% if @required.include?('content') %>required<% end %>
+              ><%= h @post.properties['content'][0] if @post.properties.key?('content') %></textarea>
+            <p class="help-block">
+              Enter content for this post.
+              You should use plain text or markup if your server supports this.
+              <code>content</code>
+            </p>
+            <%= autogrow_script('content') %>
+          <% elsif (@edit && @post.properties.key?('content') && @post.properties['content'][0].is_a?(Hash)) || (@properties.include?('content') && @subtype == 'article') %>
+            <% content_html_value = @post.properties.key?('content') && @post.properties['content'][0].is_a?(Hash) && @post.properties['content'][0].key?('html') ? h(@post.properties['content'][0]['html']) : "" %>
+            <a href="<%= request.url + "?text" %>">Switch to text</a>
+            <textarea id="content-html" class="form-control" rows="5" name="content[][html]"><%= content_html_value %></textarea>
+            <trix-editor input="content-html" style="display: none;"></trix-editor>
+            <p class="help-block">
+              Enter content for this post.
+              You may use rich content via the embedded
+              <a href="https://trix-editor.org">Trix</a> editor or, if your
+              browser does not have JavaScript enabled, you can directly enter
+              HTML.
+              <code>content[][html]</code>
+            </p>
+          <% end %>
         </div>
       <% end %>
 


### PR DESCRIPTION
Previously, when creating an article, you were only presented with an HTML content block (with the Trix editor). 

This change adds a link to choose the text option or return to HTML. The default remains as HTML.

Fixes #42 