### PR TITLE
V2.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.3.1'
+ruby '2.6.5'
 
 gem 'sinatra'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,8 @@ GEM
     httparty (0.16.4)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    kramdown (2.1.0)
+    kramdown (2.3.0)
+      rexml
     link_header (0.0.8)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
@@ -31,6 +32,7 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rexml (3.2.4)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ DEPENDENCIES
   sinatra
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.6.5p114
 
 BUNDLED WITH
    1.17.3

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ alt="Micropublish demo">
 - JavaScript is not required and you can happily use Micropublish without it.
   The user interface is progressively enhanced when JavaScript is enabled.
 - Full errors and feedback displayed from your endpoints.
+- Supports the `post-status` property
+  [proposed as a Micropub extension][post-status].
 
 ---
 
@@ -184,3 +186,4 @@ a pull request through GitHub.
 [bf]: https://barryfrost.com
 [bfcontact]: https://barryfrost.com/contact
 [mp]: https://micropublish.net
+[post-status]: https://indieweb.org/Micropub-extensions#Post_Status

--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,13 @@
 # Changelog
 
-All notable changes to this project (from version 2.2.0 onwards) will be
+All notable changes to this project (from version 2.3.0 onwards) will be
 documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.0] - 2020-10-11
+## [2.3.0] - 2020-10-11
 
 ### Added
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project (from version 2.2.0 onwards) will be
+documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.2.0] - 2020-10-11
+
+### Added
+
+- [Filter syndication targets by post-type, specify checked as appropriate](https://github.com/barryf/micropublish/issues/45)
+- [Raw content instead of HTML for Articles](https://github.com/barryf/micropublish/issues/42)
+- [Make JSON the default post creation method](https://github.com/barryf/micropublish/issues/41)
+- [Support `visibility` property](https://github.com/barryf/micropublish/issues/36)
+- [Support `post-status` property](https://github.com/barryf/micropublish/issues/35)
+- [Add granular scopes to login/auth](https://github.com/barryf/micropublish/issues/33)
+
+### Changed
+
+- Only show edit, delete or undelete controls if scope allows
+- Added `draft` scope to login form
+- Force `post-status` to `draft` when using (only) draft scope
+- Bump kramdown from 2.1.0 to 2.3.0

--- a/changelog.md
+++ b/changelog.md
@@ -13,13 +13,13 @@ and this project adheres to
 
 - [Filter syndication targets by post-type, specify checked as appropriate](https://github.com/barryf/micropublish/issues/45)
 - [Raw content instead of HTML for Articles](https://github.com/barryf/micropublish/issues/42)
-- [Make JSON the default post creation method](https://github.com/barryf/micropublish/issues/41)
 - [Support `visibility` property](https://github.com/barryf/micropublish/issues/36)
 - [Support `post-status` property](https://github.com/barryf/micropublish/issues/35)
 - [Add granular scopes to login/auth](https://github.com/barryf/micropublish/issues/33)
 
 ### Changed
 
+- [Make JSON the default post creation method](https://github.com/barryf/micropublish/issues/41)
 - Only show edit, delete or undelete controls if scope allows
 - Added `draft` scope to login form
 - Force `post-status` to `draft` when using (only) draft scope

--- a/config/properties.json
+++ b/config/properties.json
@@ -1,5 +1,5 @@
 {
-	"known": [
+  "known": [
     "in-reply-to",
     "repost-of",
     "like-of",
@@ -13,63 +13,109 @@
     "mp-syndicate-to",
     "syndication",
     "mp-slug",
-    "checkin"
-	],
-	"default": [
-		"category",
-		"mp-syndicate-to",
-		"mp-slug"
-	],
-	"types": {
-		"h-entry": {
-			"note": {
-				"name": "Note",
-				"icon": "comment",
-				"properties": ["content"],
-				"required": ["content"]
-			},
-			"article": {
-				"name": "Article",
-				"icon": "file-text",
-				"properties": ["name", "content"],
-				"required": ["name", "content"]
-			},
-			"rsvp": {
-				"name": "RSVP",
-				"icon": "calendar-check-o",
-				"properties": ["in-reply-to", "rsvp", "content"],
-				"required": ["in-reply-to", "rsvp"]
-			},
-			"bookmark": {
-				"name": "Bookmark",
-				"icon": "bookmark",
-				"properties": ["bookmark-of", "name", "content"],
-				"required": ["bookmark-of", "name"]
-			},
-			"reply": {
-				"name": "Reply",
-				"icon": "reply",
-				"properties": ["in-reply-to", "content"],
-				"required": ["in-reply-to", "content"]
-			},
-			"repost": {
-				"name": "Repost",
-				"icon": "retweet",
-				"properties": ["repost-of", "content"],
-				"required": ["repost-of"]
-			},
-			"like": {
-				"name": "Like",
-				"icon": "heart",
-				"properties": ["like-of"],
-				"required": ["like-of"]
-			},
-			"checkin": {
-				"name": "Check-in",
-				"icon": "map-marker",
-				"properties": ["checkin", "content"],
-				"required": ["checkin"]
-			}
-		}
-	}
+    "checkin",
+    "post-status"
+  ],
+  "default": [
+    "category",
+    "post-status",
+    "mp-syndicate-to",
+    "mp-slug"
+  ],
+  "types": {
+    "h-entry": {
+      "note": {
+        "name": "Note",
+        "icon": "comment",
+        "properties": [
+          "content"
+        ],
+        "required": [
+          "content"
+        ]
+      },
+      "article": {
+        "name": "Article",
+        "icon": "file-text",
+        "properties": [
+          "name",
+          "content"
+        ],
+        "required": [
+          "name",
+          "content"
+        ]
+      },
+      "rsvp": {
+        "name": "RSVP",
+        "icon": "calendar-check-o",
+        "properties": [
+          "in-reply-to",
+          "rsvp",
+          "content"
+        ],
+        "required": [
+          "in-reply-to",
+          "rsvp"
+        ]
+      },
+      "bookmark": {
+        "name": "Bookmark",
+        "icon": "bookmark",
+        "properties": [
+          "bookmark-of",
+          "name",
+          "content"
+        ],
+        "required": [
+          "bookmark-of",
+          "name"
+        ]
+      },
+      "reply": {
+        "name": "Reply",
+        "icon": "reply",
+        "properties": [
+          "in-reply-to",
+          "content"
+        ],
+        "required": [
+          "in-reply-to",
+          "content"
+        ]
+      },
+      "repost": {
+        "name": "Repost",
+        "icon": "retweet",
+        "properties": [
+          "repost-of",
+          "content"
+        ],
+        "required": [
+          "repost-of"
+        ]
+      },
+      "like": {
+        "name": "Like",
+        "icon": "heart",
+        "properties": [
+          "like-of"
+        ],
+        "required": [
+          "like-of"
+        ]
+      },
+      "checkin": {
+        "name": "Check-in",
+        "icon": "map-marker",
+        "properties": [
+          "checkin",
+          "content"
+        ],
+        "required": [
+          "checkin"
+        ]
+      }
+    }
+  }
 }

--- a/config/properties.json
+++ b/config/properties.json
@@ -14,11 +14,13 @@
     "syndication",
     "mp-slug",
     "checkin",
-    "post-status"
+    "post-status",
+    "visibility"
   ],
   "default": [
     "category",
     "post-status",
+    "visibility",
     "mp-syndicate-to",
     "mp-slug"
   ],

--- a/lib/micropublish/auth.rb
+++ b/lib/micropublish/auth.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module Micropublish
   class Auth
 

--- a/lib/micropublish/helpers.rb
+++ b/lib/micropublish/helpers.rb
@@ -18,10 +18,10 @@ module Micropublish
     end
 
     def default_format
-      if session.key?('format') && session[:format] == :json
-        :json
-      else
+      if session.key?('format') && session[:format] == :form
         :form
+      else
+        :json
       end
     end
 

--- a/lib/micropublish/micropub.rb
+++ b/lib/micropublish/micropub.rb
@@ -6,14 +6,17 @@ module Micropublish
       @token = token
     end
 
-    def syndicate_to(subtype = nil)
-      query = { q: 'syndicate-to' }
-      query['post-type'] = subtype if subtype
+    def try_syndicate_to(query)
       begin
         response = HTTParty.get(@micropub, query: query, headers: headers)
         JSON.parse(response.body)['syndicate-to']
       rescue
       end
+    end
+
+    def syndicate_to(subtype = nil)
+      try_syndicate_to({ q: 'syndicate-to', 'post-type': subtype }) ||
+        try_syndicate_to({ q: 'config' })
     end
 
     def source_all(url)

--- a/lib/micropublish/micropub.rb
+++ b/lib/micropublish/micropub.rb
@@ -6,8 +6,9 @@ module Micropublish
       @token = token
     end
 
-    def syndicate_to
-      query = { q: 'config' }
+    def syndicate_to(subtype = nil)
+      query = { q: 'syndicate-to' }
+      query['post-type'] = subtype if subtype
       begin
         response = HTTParty.get(@micropub, query: query, headers: headers)
         JSON.parse(response.body)['syndicate-to']

--- a/lib/micropublish/post.rb
+++ b/lib/micropublish/post.rb
@@ -11,7 +11,8 @@ module Micropublish
     def self.properties_from_params(params)
       props = {}
       params.keys.each do |param|
-        next if params[param].empty? || params[param] == [""]
+        next if params[param].nil? || params[param].empty? ||
+          params[param] == [""]
         if param.start_with?('_')
           next
         elsif param == 'mp-syndicate-to'

--- a/lib/micropublish/server.rb
+++ b/lib/micropublish/server.rb
@@ -25,10 +25,6 @@ module Micropublish
         session[:me] = 'http://localhost:4444/'
         session[:micropub] = 'http://localhost:3333/micropub'
         session[:scope] = 'create update delete undelete'
-        session[:syndicate_to] = [{
-          "uid" => "https://twitter.com/barryfdata",
-          "name" => "Twitter (barryfdata)"
-        }]
       end
     end
 
@@ -285,12 +281,8 @@ module Micropublish
         redirect url
       end
 
-      def syndicate_to
-        begin
-          session[:syndicate_to] ||= micropub.syndicate_to || []
-        rescue MicropublishError => e
-          redirect_flash('/', 'danger', e.message)
-        end
+      def syndicate_to(subtype = nil)
+        micropub.syndicate_to(subtype) || []
       end
 
       def logged_in?

--- a/lib/micropublish/server.rb
+++ b/lib/micropublish/server.rb
@@ -22,8 +22,8 @@ module Micropublish
 
     before do
       unless settings.production?
-        session[:me] = 'http://localhost:9394/'
-        session[:micropub] = 'http://localhost:9394/micropub'
+        session[:me] = 'http://localhost:4444/'
+        session[:micropub] = 'http://localhost:3333/micropub'
         session[:scope] = 'create update delete undelete'
         session[:syndicate_to] = [{
           "uid" => "https://twitter.com/barryfdata",

--- a/lib/micropublish/server.rb
+++ b/lib/micropublish/server.rb
@@ -49,8 +49,8 @@ module Micropublish
           Auth.valid_uri?(params[:me])
         raise "Missing or invalid value for \"me\": \"#{h params[:me]}\"."
       end
-      unless params.key?('scope') && (params[:scope] == 'post' ||
-          params[:scope] == 'create update delete undelete')
+      unless params.key?('scope') && (params[:scope].include?('create') ||
+          params[:scope].include?('post'))
         raise "You must specify a valid scope."
       end
       unless endpoints = EndpointsFinder.new(params[:me]).find_links
@@ -59,7 +59,7 @@ module Micropublish
       # define random state string
       session[:state] = Random.new_seed.to_s
       # store scope - will be needed to limit functionality on dashboard
-      session[:scope] = params[:scope]
+      session[:scope] = params[:scope].join(' ')
       # store me - we don't want to trust this in callback
       session[:me] = params[:me]
       # redirect to auth endpoint

--- a/lib/micropublish/server.rb
+++ b/lib/micropublish/server.rb
@@ -11,6 +11,7 @@ module Micropublish
       set :properties,
         JSON.parse(File.read("#{root_path}config/properties.json"))
       set :readme, File.read("#{root_path}README.md")
+      set :changelog, File.read("#{root_path}/changelog.md")
       set :help, File.read("#{public_folder}/help.md")
 
       set :server, :puma
@@ -250,7 +251,16 @@ module Micropublish
 
     get '/about' do
       @content = markdown(settings.readme)
+      # use a better heading for the about page
+      @content.sub!('<h1 id="micropublish">Micropublish</h1>',
+        '<h1>About</h1>')
       @title = "About"
+      erb :static
+    end
+
+    get '/changelog' do
+      @content = markdown(settings.changelog)
+      @title = "Changelog"
       erb :static
     end
 

--- a/lib/micropublish/version.rb
+++ b/lib/micropublish/version.rb
@@ -1,5 +1,5 @@
 module Micropublish
 
-  VERSION = "3.0.0"
+  VERSION = "2.2.0"
 
 end

--- a/lib/micropublish/version.rb
+++ b/lib/micropublish/version.rb
@@ -1,5 +1,5 @@
 module Micropublish
 
-  VERSION = "2.1.0"
+  VERSION = "3.0.0"
 
 end

--- a/lib/micropublish/version.rb
+++ b/lib/micropublish/version.rb
@@ -1,5 +1,5 @@
 module Micropublish
 
-  VERSION = "2.2.0"
+  VERSION = "2.3.0"
 
 end

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -40,28 +40,35 @@
   </div>
 </div>
 
-<form action="/edit" method="get"
-    <% if session[:scope] == 'post' %>hidden<% end %>>
+<% if session[:scope].split(' ').any? { |s| ['update', 'delete', 'undelete'].include?(s) } %>
+<form action="/edit" method="get">
   <div class="panel panel-default">
     <div class="panel-heading">
-      <h3 class="panel-title">Update an existing post</h3>
+      <h3 class="panel-title">Modify an existing post</h3>
     </div>
     <div class="panel-body">
       <input type="url" class="form-control" name="url" required>
       <p class="help-block">
-        Enter the URL of a post on your site that you wish to update.
+        Enter the absolute URL of a post on your site.
       </p>
     </div>
     <div class="panel-footer">
-      <button name="edit" class="btn btn-default">Edit</button>
-      &nbsp;
-      <button name="edit-all" class="btn btn-default"
-        title="&quot;The Kitchen Sink&quot; editor">Edit all</button>
-      &nbsp;
+      <% if session[:scope].split(' ').include?('update') %>
+        <button name="edit" class="btn btn-default">Edit</button>
+        &nbsp;
+        <button name="edit-all" class="btn btn-default"
+          title="&quot;The Kitchen Sink&quot; editor">Edit all</button>
+        &nbsp;
+      <% end %>
       <div class="btn-group" role="group">
-        <button name="delete" class="btn btn-default">Delete</button>
-        <button name="undelete" class="btn btn-default">Undelete</button>
+        <% if session[:scope].split(' ').include?('delete') %>
+          <button name="delete" class="btn btn-default">Delete</button>
+        <% end %>
+        <% if session[:scope].split(' ').include?('undelete') %>
+          <button name="undelete" class="btn btn-default">Undelete</button>
+        <% end %>
       </div>
     </div>
   </div>
 </form>
+<% end %>

--- a/views/form.erb
+++ b/views/form.erb
@@ -345,7 +345,15 @@
 
       <% if @all || @properties.include?('post-status') || @properties.include?('visibility') %>
         <div class="form-inline">
-          <% if @all || @properties.include?('post-status') %>
+          <% scopes_array = session[:scope].split(' ') %>
+          <% if !scopes_array.include?('create') || scopes_array == ['draft'] %>
+            <div class="form-group">
+              <label for="post-status">Status&nbsp;</label>
+              <select class="form-control" id="post-status" name="post-status" style="margin-right: 20px;">
+                <option>draft</option>
+              </select>
+            </div>
+          <% elsif @all || @properties.include?('post-status') %>
             <div class="form-group">
               <label for="post-status">
                 Status&nbsp;

--- a/views/form.erb
+++ b/views/form.erb
@@ -342,18 +342,52 @@
         </div>
       <% end %>
 
-      <% if @all || @properties.include?('post-status') %>
+      <% if @all || @properties.include?('post-status') || @properties.include?('visibility') %>
         <div class="form-inline">
-          <label for="post-status">
-            Status&nbsp;
-            <% if @required.include?('post-status') %><span class="required" title="required">*</span><% end %>
-          </label>
-          <select class="form-control" id="post-status" name="post-status"
-              <% if @required.include?('post-status') %>required<% end %>>
-            <option></option>
-            <option<% if @post.properties.key?('post-status') && @post.properties['post-status'][0] == 'published' %> selected<% end %>>published</option>
-            <option<% if @post.properties.key?('post-status') && @post.properties['post-status'][0] == 'draft' %> selected<% end %>>draft</option>
-          </select>
+
+          <% if @all || @properties.include?('post-status') %>
+            <label for="post-status">
+              Status&nbsp;
+              <% if @required.include?('post-status') %><span class="required" title="required">*</span><% end %>
+            </label>
+            <select class="form-control" id="post-status" name="post-status" style="margin-right: 20px;"
+                <% if @required.include?('post-status') %>required<% end %>>
+              <option></option>
+              <option<% if @post.properties.key?('post-status') && @post.properties['post-status'][0] == 'published' %> selected<% end %>>published</option>
+              <option<% if @post.properties.key?('post-status') && @post.properties['post-status'][0] == 'draft' %> selected<% end %>>draft</option>
+            </select>
+          <% end %>
+
+          <% if @all || @properties.include?('visibility') %>
+            <label for="visibility">
+              Visibility&nbsp;
+              <% if @required.include?('visibility') %><span class="required" title="required">*</span><% end %>
+            </label>
+            <select class="form-control" id="post-status" name="visibility"
+                <% if @required.include?('visibility') %>required<% end %>>
+              <option></option>
+              <option<% if @post.properties.key?('visibility') && @post.properties['visibility'][0] == 'public' %> selected<% end %>>public</option>
+              <option<% if @post.properties.key?('visibility') && @post.properties['visibility'][0] == 'unlisted' %> selected<% end %>>unlisted</option>
+              <option<% if @post.properties.key?('visibility') && @post.properties['visibility'][0] == 'private' %> selected<% end %>>private</option>
+            </select>
+            &nbsp;
+          <% end %>
+
+          <p class="help-block">
+            <% if @all || @properties.include?('post-status') %>
+              Choose whether your post should be published or made a draft.
+              <code>post-status</code>
+            <% end %>
+            <% if @all || @properties.include?('visibility') %>
+              Select a visibility setting to indicate to your server whether
+              this post should be made public, excluded from lists or be hidden
+              as a private post.
+              <code>visibility</code>
+            <% end %>
+            NB: Please check whether your server supports these values, or leave
+            blank (default).
+          </p>
+
         </div>
       <% end %>
 

--- a/views/form.erb
+++ b/views/form.erb
@@ -271,7 +271,7 @@
           <% syndicate_to(@subtype).each do |syndication| %>
             <label class="checkbox-inline">
               <input type="checkbox" name="mp-syndicate-to[]" value="<%= h syndication['uid'] %>"
-                <% if (syndication.key?('checked') && syndication['checked']) ||
+                <% if (!@edit && request.get? && syndication.key?('checked') && syndication['checked']) ||
                   (@post.properties.key?('mp-syndicate-to') && @post.properties['mp-syndicate-to'].include?(syndication['uid'])) %>
                   checked
                 <% end %>

--- a/views/form.erb
+++ b/views/form.erb
@@ -342,6 +342,21 @@
         </div>
       <% end %>
 
+      <% if @all || @properties.include?('post-status') %>
+        <div class="form-inline">
+          <label for="post-status">
+            Status&nbsp;
+            <% if @required.include?('post-status') %><span class="required" title="required">*</span><% end %>
+          </label>
+          <select class="form-control" id="post-status" name="post-status"
+              <% if @required.include?('post-status') %>required<% end %>>
+            <option></option>
+            <option<% if @post.properties.key?('post-status') && @post.properties['post-status'][0] == 'published' %> selected<% end %>>published</option>
+            <option<% if @post.properties.key?('post-status') && @post.properties['post-status'][0] == 'draft' %> selected<% end %>>draft</option>
+          </select>
+        </div>
+      <% end %>
+
     </div>
 
     <div class="panel-footer">

--- a/views/form.erb
+++ b/views/form.erb
@@ -268,11 +268,13 @@
             <% if @required.include?('mp-syndicate-to') %><span class="required" title="required">*</span><% end %>
           </label>
           <br>
-          <% syndicate_to.each do |syndication| %>
+          <% syndicate_to(@subtype).each do |syndication| %>
             <label class="checkbox-inline">
-              <input type="checkbox" name="mp-syndicate-to[]"
-                value="<%= h syndication['uid'] %>"
-                <% if @post.properties.key?('mp-syndicate-to') && @post.properties['mp-syndicate-to'].include?(syndication['uid']) %>checked<% end %>
+              <input type="checkbox" name="mp-syndicate-to[]" value="<%= h syndication['uid'] %>"
+                <% if (syndication.key?('checked') && syndication['checked']) ||
+                  (@post.properties.key?('mp-syndicate-to') && @post.properties['mp-syndicate-to'].include?(syndication['uid'])) %>
+                  checked
+                <% end %>
               ><%= h syndication['name'] %>
             </label>
           <% end %>

--- a/views/form.erb
+++ b/views/form.erb
@@ -343,51 +343,50 @@
 
       <% if @all || @properties.include?('post-status') || @properties.include?('visibility') %>
         <div class="form-inline">
-
           <% if @all || @properties.include?('post-status') %>
-            <label for="post-status">
-              Status&nbsp;
-              <% if @required.include?('post-status') %><span class="required" title="required">*</span><% end %>
-            </label>
-            <select class="form-control" id="post-status" name="post-status" style="margin-right: 20px;"
-                <% if @required.include?('post-status') %>required<% end %>>
-              <option></option>
-              <option<% if @post.properties.key?('post-status') && @post.properties['post-status'][0] == 'published' %> selected<% end %>>published</option>
-              <option<% if @post.properties.key?('post-status') && @post.properties['post-status'][0] == 'draft' %> selected<% end %>>draft</option>
-            </select>
+            <div class="form-group">
+              <label for="post-status">
+                Status&nbsp;
+                <% if @required.include?('post-status') %><span class="required" title="required">*</span><% end %>
+              </label>
+              <select class="form-control" id="post-status" name="post-status" style="margin-right: 20px;"
+                  <% if @required.include?('post-status') %>required<% end %>>
+                <option></option>
+                <option<% if @post.properties.key?('post-status') && @post.properties['post-status'][0] == 'published' %> selected<% end %>>published</option>
+                <option<% if @post.properties.key?('post-status') && @post.properties['post-status'][0] == 'draft' %> selected<% end %>>draft</option>
+              </select>
+            </div>
           <% end %>
-
           <% if @all || @properties.include?('visibility') %>
-            <label for="visibility">
-              Visibility&nbsp;
-              <% if @required.include?('visibility') %><span class="required" title="required">*</span><% end %>
-            </label>
-            <select class="form-control" id="post-status" name="visibility"
-                <% if @required.include?('visibility') %>required<% end %>>
-              <option></option>
-              <option<% if @post.properties.key?('visibility') && @post.properties['visibility'][0] == 'public' %> selected<% end %>>public</option>
-              <option<% if @post.properties.key?('visibility') && @post.properties['visibility'][0] == 'unlisted' %> selected<% end %>>unlisted</option>
-              <option<% if @post.properties.key?('visibility') && @post.properties['visibility'][0] == 'private' %> selected<% end %>>private</option>
-            </select>
-            &nbsp;
+            <div class="form-group">
+              <label for="visibility">
+                Visibility&nbsp;
+                <% if @required.include?('visibility') %><span class="required" title="required">*</span><% end %>
+              </label>
+              <select class="form-control" id="post-status" name="visibility"
+                  <% if @required.include?('visibility') %>required<% end %>>
+                <option></option>
+                <option<% if @post.properties.key?('visibility') && @post.properties['visibility'][0] == 'public' %> selected<% end %>>public</option>
+                <option<% if @post.properties.key?('visibility') && @post.properties['visibility'][0] == 'unlisted' %> selected<% end %>>unlisted</option>
+                <option<% if @post.properties.key?('visibility') && @post.properties['visibility'][0] == 'private' %> selected<% end %>>private</option>
+              </select>
+            </div>
           <% end %>
-
-          <p class="help-block">
-            <% if @all || @properties.include?('post-status') %>
-              Choose whether your post should be published or made a draft.
-              <code>post-status</code>
-            <% end %>
-            <% if @all || @properties.include?('visibility') %>
-              Select a visibility setting to indicate to your server whether
-              this post should be made public, excluded from lists or be hidden
-              as a private post.
-              <code>visibility</code>
-            <% end %>
-            NB: Please check whether your server supports these values, or leave
-            blank (default).
-          </p>
-
         </div>
+        <p class="help-block">
+          <% if @all || @properties.include?('post-status') %>
+            Choose whether your post should be published or made a draft.
+            <code>post-status</code>
+          <% end %>
+          <% if @all || @properties.include?('visibility') %>
+            Select a visibility setting to indicate to your server whether
+            this post should be made public, excluded from lists or be hidden
+            as a private post.
+            <code>visibility</code>
+          <% end %>
+          NB: Please check whether your server supports these values, or leave
+          blank (default).
+        </p>
       <% end %>
 
     </div>

--- a/views/form.erb
+++ b/views/form.erb
@@ -188,42 +188,41 @@
         </div>
       <% end %>
 
-      <% if (@edit && @post.properties.key?('content') && !@post.properties['content'][0].is_a?(Hash)) || (@properties.include?('content') && @subtype != 'article') %>
+      <% if @all || @properties.include?('content') %>
         <div class="form-group">
           <label for="content">
             Content
             <% if @required.include?('content') %><span class="required" title="required">*</span><% end %>
           </label>
-          <div style="float: right;">
-            <span class="badge" id="content_count"></span>
-          </div>
-          <textarea class="form-control" rows="5" name="content" id="content"
-            <% if @required.include?('content') %>required<% end %>
-            ><%= h @post.properties['content'][0] if @post.properties.key?('content') %></textarea>
-          <p class="help-block">
-            Enter content for this post.
-            You should use plain text or markup if your server supports this.
-            <code>content</code>
-          </p>
-        </div>
-        <%= autogrow_script('content') %>
-      <% elsif (@edit && @post.properties.key?('content') && @post.properties['content'][0].is_a?(Hash)) || (@properties.include?('content') && @subtype == 'article') %>
-        <% content_html_value = @post.properties.key?('content') && @post.properties['content'][0].is_a?(Hash) && @post.properties['content'][0].key?('html') ? h(@post.properties['content'][0]['html']) : "" %>
-        <div class="form-group">
-          <label>
-            Content (HTML)
-            <% if @required.include?('content') %><span class="required" title="required">*</span><% end %>
-          </label>
-          <textarea id="content-html" class="form-control" rows="5" name="content[][html]"><%= content_html_value %></textarea>
-          <trix-editor input="content-html" style="display: none;"></trix-editor>
-          <p class="help-block">
-            Enter content for this post.
-            You may use rich content via the embedded
-            <a href="https://trix-editor.org">Trix</a> editor or, if your
-            browser does not have JavaScript enabled, you can directly enter
-            HTML.
-            <code>content[][html]</code>
-          </p>
+          &nbsp;
+          <% if (@edit && @post.properties.key?('content') && !@post.properties['content'][0].is_a?(Hash)) || (@properties.include?('content') && @subtype != 'article') || (@properties.include?('content') && params.key?('text')) %>
+            <% if @subtype == 'article' %><a href="<%= request.url.sub(/\?text$/, '') %>">Switch to HTML</a><% end %>
+            <div style="float: right;">
+              <span class="badge" id="content_count"></span>
+            </div>
+            <textarea class="form-control" rows="5" name="content" id="content"
+              <% if @required.include?('content') %>required<% end %>
+              ><%= h @post.properties['content'][0] if @post.properties.key?('content') %></textarea>
+            <p class="help-block">
+              Enter content for this post.
+              You should use plain text or markup if your server supports this.
+              <code>content</code>
+            </p>
+            <%= autogrow_script('content') %>
+          <% elsif (@edit && @post.properties.key?('content') && @post.properties['content'][0].is_a?(Hash)) || (@properties.include?('content') && @subtype == 'article') %>
+            <% content_html_value = @post.properties.key?('content') && @post.properties['content'][0].is_a?(Hash) && @post.properties['content'][0].key?('html') ? h(@post.properties['content'][0]['html']) : "" %>
+            <a href="<%= request.url + "?text" %>">Switch to text</a>
+            <textarea id="content-html" class="form-control" rows="5" name="content[][html]"><%= content_html_value %></textarea>
+            <trix-editor input="content-html" style="display: none;"></trix-editor>
+            <p class="help-block">
+              Enter content for this post.
+              You may use rich content via the embedded
+              <a href="https://trix-editor.org">Trix</a> editor or, if your
+              browser does not have JavaScript enabled, you can directly enter
+              HTML.
+              <code>content[][html]</code>
+            </p>
+          <% end %>
         </div>
       <% end %>
 

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -49,6 +49,7 @@
             <form action="/logout" method="post" class="form-inline logout">
               <p>
                 <code><%= session[:me] %></code>&nbsp;
+                <code title="scope"><%= session[:scope] %></code>&nbsp;
                 <button class="btn btn-default btn-xs" type="submit">
                   Sign out
                 </button>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -41,11 +41,11 @@
       </div>
     </div>
 
-    <% if logged_in? %>
-      <hr>
-      <div class="container">
-        <div class="row">
-          <div class="col-md-12">
+    <hr>
+    <div class="container">
+      <div class="row">
+        <div class="col-md-12">
+          <% if logged_in? %>
             <form action="/logout" method="post" class="form-inline logout">
               <p>
                 <code><%= session[:me] %></code>&nbsp;
@@ -55,13 +55,13 @@
                 </button>
               </p>
             </form>
-            <a href="/">Dashboard</a>
-            &middot;
-            <a href="/about">About</a>
-          </div>
+          <% end %>
+          <a href="/about">About</a>
+          &middot;
+          <a href="/changelog">Changelog</a>
         </div>
       </div>
-    <% end %>
+    </div>
 
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
       integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"

--- a/views/login.erb
+++ b/views/login.erb
@@ -32,6 +32,10 @@
             <code>undelete</code>
           </label>
           <label class="checkbox-inline">
+            <input type="checkbox" name="scope[]" value="draft">
+            <code>draft</code>
+          </label>
+          <label class="checkbox-inline">
             <input type="checkbox" name="scope[]" value="post">
             <code>post</code>
           </label>

--- a/views/login.erb
+++ b/views/login.erb
@@ -1,31 +1,46 @@
 <div class="panel panel-primary">
   <div class="panel-heading">
-    <h3 class="panel-title">Sign in with your Micropub site URL</h3>
+    <h3 class="panel-title">Sign in</h3>
   </div>
   <div class="panel-body">
 
-    <form action="/auth" method="get">
+    <form action="/auth" method="get" class="form-horizontal">
       <div class="form-group">
-        <input type="url" class="form-control" name="me" value="<%= @me %>"
-          placeholder="https://">
+        <label for="me" class="col-sm-2 control-label">Micropub URL</label>
+        <div class="col-sm-10">
+          <input type="url" class="form-control" name="me" value="<%= @me %>"
+            placeholder="https://">
+        </div>
       </div>
       <div class="form-group">
-        <div class="radio">
-          <label>
-            <input type="radio" name="scope" value="post" checked>
+        <label class="col-sm-2 control-label">Scope(s)</label>
+        <div class="col-sm-10">
+          <label class="checkbox-inline">
+            <input type="checkbox" name="scope[]" value="create" checked>
+            <code>create</code>
+          </label>
+          <label class="checkbox-inline">
+            <input type="checkbox" name="scope[]" value="update" checked>
+            <code>update</code>
+          </label>
+          <label class="checkbox-inline">
+            <input type="checkbox" name="scope[]" value="delete" checked>
+            <code>delete</code>
+          </label>
+          <label class="checkbox-inline">
+            <input type="checkbox" name="scope[]" value="undelete" checked>
+            <code>undelete</code>
+          </label>
+          <label class="checkbox-inline">
+            <input type="checkbox" name="scope[]" value="post">
             <code>post</code>
           </label>
         </div>
-        <div class="radio">
-          <label>
-            <input type="radio" name="scope"
-              value="create update delete undelete">
-            <code>create update delete undelete</code>
-          </label>
-        </div>
       </div>
-      <div>
-        <button class="btn btn-primary" type="submit">Sign in</button>
+      <div class="form-group">
+        <div class="col-sm-offset-2 col-sm-10">
+          <button class="btn btn-primary" type="submit">Sign in</button>
+        </div>
       </div>
     </form>
 

--- a/views/login.erb
+++ b/views/login.erb
@@ -1,3 +1,9 @@
+<p class="lead">
+  Create or modify posts on your
+  <a href="https://micropub.net">Micropub</a>-compatible website.
+  <a href="/about">Find out more</a> about the requirements.
+</p>
+
 <div class="panel panel-primary">
   <div class="panel-heading">
     <h3 class="panel-title">Sign in</h3>
@@ -6,10 +12,10 @@
 
     <form action="/auth" method="get" class="form-horizontal">
       <div class="form-group">
-        <label for="me" class="col-sm-2 control-label">Micropub URL</label>
+        <label for="me" class="col-sm-2 control-label">Micropub&nbsp;URL</label>
         <div class="col-sm-10">
           <input type="url" class="form-control" name="me" value="<%= @me %>"
-            placeholder="https://">
+            placeholder="https://" required>
         </div>
       </div>
       <div class="form-group">
@@ -49,8 +55,4 @@
     </form>
 
   </div>
-</div>
-
-<div id="static">
-<%= @about %>
 </div>


### PR DESCRIPTION
### Added

- Closes #45 [Filter syndication targets by post-type, specify checked as appropriate](https://github.com/barryf/micropublish/issues/45)
- Closes #42 [Raw content instead of HTML for Articles](https://github.com/barryf/micropublish/issues/42)
- Closes #36 [Support `visibility` property](https://github.com/barryf/micropublish/issues/36)
- Closes #35 [Support `post-status` property](https://github.com/barryf/micropublish/issues/35)
- Closes #33 [Add granular scopes to login/auth](https://github.com/barryf/micropublish/issues/33)

### Changed

- Closes #41 [Make JSON the default post creation method](https://github.com/barryf/micropublish/issues/41)
- Closes #39 [Bump kramdown from 2.1.0 to 2.3.0](https://github.com/barryf/micropublish/issues/39)
- Only show edit, delete or undelete controls if scope allows
- Added `draft` scope to login form
- Force `post-status` to `draft` when using (only) draft scope

