### PR TITLE
Present authorized scopes to user, post-auth

### DIFF
--- a/lib/micropublish/server.rb
+++ b/lib/micropublish/server.rb
@@ -102,11 +102,11 @@ module Micropublish
         request.base_url,
         session[:code_verifier]
       )
-      endpoints_and_token_and_me = auth.callback
-      # login and token grant was successful so store in session with me
-      session.merge!(endpoints_and_token_and_me)
+      endpoints_and_token_and_scope_and_me = auth.callback
+      # login and token grant was successful so store in session with the scope for the token and the me
+      session.merge!(endpoints_and_token_and_scope_and_me)
       redirect_flash('/', 'success', %Q{You are now signed in successfully
-          as "#{endpoints_and_token_and_me[:me]}".
+          as "#{endpoints_and_token_and_scope_and_me[:me]}".
           Submit content to your site via Micropub using the links
           below. Please
           <a href="/about" class="alert-link">read&nbsp;the&nbsp;docs</a> for


### PR DESCRIPTION
Previously, the scopes that were presented to the user (alongside their
`me`) were the scopes that Micropublish requested, rather than the
scopes returned by the authorization server.

We should make sure we present those that were actually returned by the
token endpoint.

To match the intent, we should update our methods to note that they also
return the `scope`, and make sure we update our session object with it.