### PR TITLE
V2.5.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2021-03-28
+
+### Changed
+
+- Character counter now works for fields other than `content`. If a `summary`
+  field is available this will now include a counter.
+- Support changing article content field type: (Trix) Editor, HTML or Text.
+  The options available depends on whether you're creating or updating an
+  article -- you cannot switch to Text if you're editing an HTML article.
+- When redirecting after creating/updating a post, the URL parameter is now
+  passed in the query-string, instead of in the session. This is intended as
+  a short-term fix for large sessions, as discussed in Issue #62.
+
 ## [2.4.5] - 2021-03-01
 
 ### Changed

--- a/lib/micropublish/server.rb
+++ b/lib/micropublish/server.rb
@@ -286,13 +286,12 @@ module Micropublish
 
     get '/redirect' do
       require_session
-      redirect '/' unless session.key?(:redirect)
-      @url = session[:redirect]
+      redirect '/' unless params.key?('url')
+      @url = params['url']
       # HTTP request to see if post exists yet
       response = HTTParty.get(@url)
       case response.code.to_i
       when 200
-        session.delete(:redirect)
         redirect @url
       when 404
         erb :redirect
@@ -426,8 +425,8 @@ module Micropublish
       end
 
       def redirect_post(url)
-        session[:redirect] = url
-        redirect "/redirect"
+        encoded_url = CGI.escape(url)
+        redirect "/redirect?url=#{encoded_url}"
       end
     end
 

--- a/lib/micropublish/version.rb
+++ b/lib/micropublish/version.rb
@@ -1,5 +1,5 @@
 module Micropublish
 
-  VERSION = "2.4.5"
+  VERSION = "2.5.0"
 
 end

--- a/public/scripts/micropublish.js
+++ b/public/scripts/micropublish.js
@@ -20,18 +20,22 @@ $(function() {
 		return false
 	});
 
-	function count_content() {
-     $('#content_count').html(
+	function count_chars(id) {
+     $('#' + id + '_count').html(
 			 "<span class=\"fa fa-twitter\"></span> " +
 			 twttr.txt.getTweetLength(
-				 $('#content').val()
+				 $('#' + id).val()
 			 )
 		 );
 	}
 	if ($('#content_count').length) {
-		$('#content').on('change keyup', count_content);
-		count_content();
+		$('#content').on('change keyup', function() { count_chars('content'); });
+		count_chars('content');
 	}
+  if ($('#summary_count').length) {
+    $('#summary').on('change keyup', function() { count_chars('summary'); });
+    count_chars('summary');
+  }
 
 	$('#helpable-toggle').on('click', function() {
 		$('.helpable .help-block').slideToggle();

--- a/views/form.erb
+++ b/views/form.erb
@@ -195,8 +195,12 @@
             <% if @required.include?('content') %><span class="required" title="required">*</span><% end %>
           </label>
           &nbsp;
-          <% if (@edit && @post.properties.key?('content') && !@post.properties['content'][0].is_a?(Hash)) || (@properties.include?('content') && @subtype != 'article') || (@properties.include?('content') && params.key?('text')) %>
-            <% if @subtype == 'article' %><a href="<%= request.url.sub(/\?text$/, '') %>">Switch to HTML</a><% end %>
+          <% if (@edit && @post.properties.key?('content') && !@post.properties['content'][0].is_a?(Hash)) || (@properties.include?('content') && @subtype != 'article') || (@properties.include?('content') && params.key?('format') && params['format'] == 'text') %>
+            <% if @subtype == 'article' && !@edit %>
+              <a href="?<%= URI.encode_www_form(params.merge({format:'editor'})) %>">Editor</a> |
+              <a href="?<%= URI.encode_www_form(params.merge({format:'html'})) %>">HTML</a> |
+              <strong>Text</strong>
+            <% end %>
             <div style="float: right;">
               <span class="badge" id="content_count"></span>
             </div>
@@ -210,10 +214,27 @@
             </p>
             <%= autogrow_script('content') %>
           <% elsif (@edit && @post.properties.key?('content') && @post.properties['content'][0].is_a?(Hash)) || (@properties.include?('content') && @subtype == 'article') %>
+            <% if !params.key?('format') || params['format'] == 'editor' %>
+              <strong>Editor</strong>
+            <% else %>
+              <a href="?<%= URI.encode_www_form(params.merge({format:'editor'})) %>">Editor</a>
+            <% end %> |
+            <% if params.key?('format') && params['format'] == 'html' %>
+              <strong>HTML</strong>
+            <% else %>
+              <a href="?<%= URI.encode_www_form(params.merge({format:'html'})) %>">HTML</a>
+            <% end %>
+            <% unless @edit %>
+              | <a href="?<%= URI.encode_www_form(params.merge({format:'text'})) %>">Text</a>
+            <% end %>
             <% content_html_value = @post.properties.key?('content') && @post.properties['content'][0].is_a?(Hash) && @post.properties['content'][0].key?('html') ? h(@post.properties['content'][0]['html']) : "" %>
-            <a href="<%= request.url + "?text" %>">Switch to text</a>
-            <textarea id="content-html" class="form-control" rows="5" name="content[][html]"><%= content_html_value %></textarea>
-            <trix-editor input="content-html" style="display: none;"></trix-editor>
+            <% if params.key?('format') && params['format'] == 'html' %>
+              <textarea id="content" class="form-control" rows="5" name="content[][html]"><%= content_html_value %></textarea>
+              <%= autogrow_script('content') %>
+            <% else %>
+              <textarea id="content-html" class="form-control" rows="5" name="content[][html]"><%= content_html_value %></textarea>
+              <trix-editor input="content-html" style="display: none;"></trix-editor>
+            <% end %>
             <p class="help-block">
               Enter content for this post.
               You may use rich content via the embedded

--- a/views/form.erb
+++ b/views/form.erb
@@ -232,7 +232,10 @@
             Summary
             <% if @required.include?('summary') %><span class="required" title="required">*</span><% end %>
           </label>
-          <textarea class="form-control" rows="2" name="summary"
+          <div style="float: right;">
+            <span class="badge" id="summary_count"></span>
+          </div>
+          <textarea class="form-control" rows="2" name="summary" id="summary"
             <% if @required.include?('summary') %>required<% end %>
             ><%= h @post.properties['summary'][0] if @post.properties.key?('summary') %></textarea>
           <p class="help-block">

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -69,6 +69,6 @@
     <script src="/scripts/twitter-text.js"></script>
     <script src="/scripts/jquery.ns-autogrow.min.js"></script>
     <script src="/scripts/bootstrap-tokenfield.min.js"></script>
-    <script src="/scripts/micropublish.js"></script>
+    <script src="/scripts/micropublish.js?v=20210316"></script>
   </body>
 </html>


### PR DESCRIPTION
### Changed
- Character counter now works for fields other than `content`. If a `summary`
  field is available this will now include a counter.
- Support changing article content field type: (Trix) Editor, HTML or Text.
  The options available depends on whether you're creating or updating an
  article -- you cannot switch to Text if you're editing an HTML article.
- When redirecting after creating/updating a post, the URL parameter is now
  passed in the query-string, instead of in the session. This is intended as
  a short-term fix for large sessions, as discussed in Issue #62.