### PR TITLE
Ignore unknown/unsupported properties from server

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.1] - 2021-04-03
+
+### Fixed
+
+- [Ignore unknown/unsupported properties from server](https://github.com/barryf/micropublish/pull/68).
+  If your server specifies `post-type` properties and includes properties that
+  Micropublish didn't know, when updating a post using one of these properties
+  it was possible for them to be marked as removed in the update request.
+
 ## [2.5.0] - 2021-03-28
 
 ### Changed

--- a/lib/micropublish/version.rb
+++ b/lib/micropublish/version.rb
@@ -1,5 +1,5 @@
 module Micropublish
 
-  VERSION = "2.5.0"
+  VERSION = "2.5.1"
 
 end


### PR DESCRIPTION
When updating a post, to decide if a property has been removed, a list of known properties is compared with those that have been submitted. However, if a server specifies its own post-type properties, it's possible for any unknown/unsupported properties to be considered removed because they were not on the known list.

This PR changes it so that if a server specifies its own properties they are used as the known list. NB: Micropublish continues to add `syndication` and `published` to any list because these are considered default properties.

Fixes #67 