### PR TITLE
Always use UTF-8 charset for JSON requests

### DIFF
--- a/lib/micropublish/micropub.rb
+++ b/lib/micropublish/micropub.rb
@@ -74,7 +74,7 @@ module Micropublish
     def headers
       {
         'Authorization' => "Bearer #{@token}",
-        'Content-Type' => 'application/json',
+        'Content-Type' => 'application/json; charset=utf-8',
         'Accept' => 'application/json'
       }
     end

--- a/lib/micropublish/request.rb
+++ b/lib/micropublish/request.rb
@@ -68,7 +68,7 @@ module Micropublish
       headers = { 'Authorization' => "Bearer #{@token}" }
       if is_json
         body = body.to_json
-        headers['Content-Type'] = 'application/json'
+        headers['Content-Type'] = 'application/json; charset=utf-8'
       end
       HTTParty.post(
         @micropub,


### PR DESCRIPTION
As noted in #77, we're seeing that JSON create/updates are stripping
UTF-8 encoding, therefore leading to emoji characters being mangled.

A fix for this should be to ensure we always encode as UTF-8.

Closes #77.