### PR TITLE
feat: add drank and ate posts

### DIFF
--- a/config/properties.json
+++ b/config/properties.json
@@ -18,7 +18,9 @@
     "visibility",
     "mp-channel",
     "photo",
-    "listen-of"
+    "listen-of",
+    "ate",
+    "drank"
   ],
   "types": {
     "h-entry": {
@@ -164,6 +166,36 @@
         ],
         "required": [
           "listen-of"
+        ]
+      },
+      "ate": {
+        "name": "Ate",
+        "icon": "cutlery",
+        "properties": [
+          "ate",
+          "photo",
+          "content",
+          "category",
+          "post-status",
+          "visibility"
+        ],
+        "required": [
+          "ate"
+        ]
+      },
+      "drank": {
+        "name": "Drank",
+        "icon": "beer",
+        "properties": [
+          "drank",
+          "photo",
+          "content",
+          "category",
+          "post-status",
+          "visibility"
+        ],
+        "required": [
+          "drank"
         ]
       }
     }

--- a/config/properties.json
+++ b/config/properties.json
@@ -168,8 +168,8 @@
           "listen-of"
         ]
       },
-      "ate": {
-        "name": "Ate",
+      "food": {
+        "name": "Food",
         "icon": "cutlery",
         "properties": [
           "ate",
@@ -183,9 +183,9 @@
           "ate"
         ]
       },
-      "drank": {
-        "name": "Drank",
-        "icon": "beer",
+      "drink": {
+        "name": "Drink",
+        "icon": "coffee",
         "properties": [
           "drank",
           "photo",

--- a/lib/micropublish/server.rb
+++ b/lib/micropublish/server.rb
@@ -121,7 +121,7 @@ module Micropublish
       redirect '/new/h-entry/note'
     end
 
-    get %r{/new/h\-entry/(note|article|bookmark|reply|repost|like|rsvp|checkin|photo|listen|ate|drank)} do
+    get %r{/new/h\-entry/(note|article|bookmark|reply|repost|like|rsvp|checkin|photo|listen|food|drink)} do
         |subtype|
       require_session
       render_new(subtype)
@@ -175,7 +175,7 @@ module Micropublish
       end
     end
 
-    get %r{/edit/h\-entry/(note|article|bookmark|reply|repost|like|rsvp|checkin|photo|listen|ate|drank)} do
+    get %r{/edit/h\-entry/(note|article|bookmark|reply|repost|like|rsvp|checkin|photo|listen|food|drink)} do
         |subtype|
       require_session
       render_edit(subtype)

--- a/lib/micropublish/server.rb
+++ b/lib/micropublish/server.rb
@@ -121,7 +121,7 @@ module Micropublish
       redirect '/new/h-entry/note'
     end
 
-    get %r{/new/h\-entry/(note|article|bookmark|reply|repost|like|rsvp|checkin|photo|listen)} do
+    get %r{/new/h\-entry/(note|article|bookmark|reply|repost|like|rsvp|checkin|photo|listen|ate|drank)} do
         |subtype|
       require_session
       render_new(subtype)

--- a/lib/micropublish/server.rb
+++ b/lib/micropublish/server.rb
@@ -175,7 +175,7 @@ module Micropublish
       end
     end
 
-    get %r{/edit/h\-entry/(note|article|bookmark|reply|repost|like|rsvp|checkin|photo|listen)} do
+    get %r{/edit/h\-entry/(note|article|bookmark|reply|repost|like|rsvp|checkin|photo|listen|ate|drank)} do
         |subtype|
       require_session
       render_edit(subtype)

--- a/views/form.erb
+++ b/views/form.erb
@@ -116,6 +116,44 @@
         <%= autogrow_script('listen-of') %>
       <% end %>
 
+      <% if @properties.include?('ate') %>
+        <input type="hidden" name="ate[][type][]" value="h-food">
+        <div class="form-group">
+          <label>
+            Ate
+            <% if @required.include?('ate') %><span class="required" title="required">*</span><% end %>
+          </label>
+
+          <input type="text" class="form-control" name="ate[][properties][name][]"
+            <% if @required.include?('ate') %>required<% end %>
+            value="<%= h @post.properties['ate'][0]['properties']['name'][0] if @post.properties.key?('ate') %>">
+
+          <p class="help-block">
+            Enter the name of the food you ate.
+            <code>ate[]</code>
+          </p>
+        </div>
+      <% end %>
+
+      <% if @properties.include?('drank') %>
+        <input type="hidden" name="drank[][type][]" value="h-food">
+        <div class="form-group">
+          <label>
+            Drank
+            <% if @required.include?('drank') %><span class="required" title="required">*</span><% end %>
+          </label>
+
+          <input type="text" class="form-control" name="drank[][properties][name][]"
+            <% if @required.include?('drank') %>required<% end %>
+            value="<%= h @post.properties['drank'][0]['properties']['name'][0] if @post.properties.key?('drank') %>">
+
+          <p class="help-block">
+            Enter the name of the food you drank.
+            <code>drank[]</code>
+          </p>
+        </div>
+      <% end %>
+
       <% if @all || @properties.include?('photo') %>
         <div class="form-group">
           <label for="photo">

--- a/views/form.erb
+++ b/views/form.erb
@@ -130,7 +130,7 @@
 
           <p class="help-block">
             Enter the name of the food you ate.
-            <code>ate[]</code>
+            <code>ate</code>
           </p>
         </div>
       <% end %>
@@ -148,8 +148,8 @@
             value="<%= h @post.properties['drank'][0]['properties']['name'][0] if @post.properties.key?('drank') %>">
 
           <p class="help-block">
-            Enter the name of the food you drank.
-            <code>drank[]</code>
+            Enter the name of the drink you drank.
+            <code>drank</code>
           </p>
         </div>
       <% end %>

--- a/views/form.erb
+++ b/views/form.erb
@@ -116,7 +116,7 @@
         <%= autogrow_script('listen-of') %>
       <% end %>
 
-      <% if @properties.include?('ate') %>
+      <% if @all || @properties.include?('ate') %>
         <input type="hidden" name="ate[][type][]" value="h-food">
         <div class="form-group">
           <label>
@@ -135,7 +135,7 @@
         </div>
       <% end %>
 
-      <% if @properties.include?('drank') %>
+      <% if @all || @properties.include?('drank') %>
         <input type="hidden" name="drank[][type][]" value="h-food">
         <div class="form-group">
           <label>


### PR DESCRIPTION
Similarly to Teacup (https://teacup.p3k.io/), adds a "drank" and "ate" posts.

Differences from Teacup:
- No media upload (see #40)
- No location (see #84)
- No summary generation ("Just drank: {drink}" or "Just ate: {food}"). I would like to have this but I'm not sure what would be the best way to do it. Perhaps we shouldn't do it in the client.
