### PR TITLE
feat: media upload

### DIFF
--- a/lib/micropublish/micropub.rb
+++ b/lib/micropublish/micropub.rb
@@ -23,7 +23,7 @@ module Micropublish
     end
 
     def media_endpoint
-      config['media-endpoint']
+      config['media-endpoint'] if config
     end
 
     def source_all(url)

--- a/lib/micropublish/micropub.rb
+++ b/lib/micropublish/micropub.rb
@@ -22,6 +22,10 @@ module Micropublish
       data['syndicate-to'] if data.is_a?(Hash) && data.key?('syndicate-to')
     end
 
+    def media_endpoint
+      config['media-endpoint']
+    end
+
     def source_all(url)
       body = get_source(url)
       Post.new(body['type'], body['properties'])

--- a/lib/micropublish/request.rb
+++ b/lib/micropublish/request.rb
@@ -62,6 +62,23 @@ module Micropublish
       end
     end
 
+    def upload(file)
+      response = HTTParty.post(
+        @micropub,
+        body: {
+          file: file
+        },
+        headers: { 'Authorization' => "Bearer #{@token}" }
+      )
+
+      case response.code.to_i
+      when 201
+        response.headers['location']
+      else
+        handle_error(response.body)
+      end
+    end
+
     private
 
     def send(body, is_json=@is_json)

--- a/lib/micropublish/server.rb
+++ b/lib/micropublish/server.rb
@@ -312,12 +312,12 @@ module Micropublish
 
       unless media_endpoint
         status 500
-        return "Media endpoint is not configured for this user."
+        return "Media endpoint is not configured for your server."
       end
 
       unless params[:file] && params[:file][:tempfile]
         status 400
-        return "No file was sent."
+        return "No file was returned from your media endpoint."
       end
 
       new_request = Request.new(media_endpoint, session[:token], false)

--- a/public/scripts/micropublish.js
+++ b/public/scripts/micropublish.js
@@ -101,6 +101,33 @@ $(function() {
 
 		fillLocation()
 	}
+
+	$('#upload_photo').on('click', function() {
+		$('#photo_file').click()
+	});
+
+	$('#photo_file').on('change', function(event) {
+		var fd = new FormData();
+		var files = event.target.files[0];
+		fd.append('file', files);
+
+		$.ajax({
+			url: '/media',
+			type: 'post',
+			data: fd,
+			contentType: false,
+			processData: false,
+			success: function(response){
+				let val = $('#photo').val() + '\n' + response
+				val = val.trim()
+				$('#photo').val(val)
+				$('#photo').attr('rows', val.split('\n').length || 1)
+			},
+			error: function(xhr, desc, error) {
+				alert(xhr.responseText);
+			}
+		});
+	});
 });
 
 $.fn.countdown = function(duration) {

--- a/public/scripts/micropublish.js
+++ b/public/scripts/micropublish.js
@@ -69,6 +69,34 @@ $(function() {
 		})
 	}
 
+	$('#upload_photo').on('click', function() {
+		$('#photo_file').click();
+		return false;
+	});
+
+	$('#photo_file').on('change', function(event) {
+		var fd = new FormData();
+		var files = event.target.files[0];
+		fd.append('file', files);
+
+		$.ajax({
+			url: '/media',
+			type: 'post',
+			data: fd,
+			contentType: false,
+			processData: false,
+			success: function(response) {
+				var val = $('#photo').val() + '\n' + response;
+				val = val.trim();
+				$('#photo').val(val);
+				$('#photo').attr('rows', val.split('\n').length || 1);
+			},
+			error: function(xhr, desc, error) {
+				alert(xhr.responseText);
+			}
+		});
+	});
+
 	$('#find_location').on('click', function() {
 		getLocation(function (latitude, longitude) {
 			$("#latitude").val(latitude);

--- a/views/form.erb
+++ b/views/form.erb
@@ -165,15 +165,18 @@
             ><%= h @post.properties['photo'].join("\n") if @post.properties.key?('photo') %></textarea>
 
             <% if @media %>
-              <script>document.write(`
-                <input type="file" id="photo_file" name="file" style="display: none;" />
-                <button type="button" class="btn btn-default" style="margin-top: 5px;" id="upload_photo" data-toggle="button" aria-pressed="false" autocomplete="off">Upload Photo</button>
-              `)</script>
+              <input type="file" id="photo_file" name="file" style="display: none;" />
+              <button type="button" class="btn btn-default" style="margin-top: 5px;" id="upload_photo" data-toggle="button" aria-pressed="false" autocomplete="off">Upload</button>
             <% end %>
 
           <p class="help-block">
             Enter the URL of the photo.
             You can enter multiple URLs separated by whitespace if your server supports this.
+            <% if @media %>
+              <br>
+              Alternatively, click the "Upload" button to send a file to your media endpoint.
+              The photo field will then be filled with the URL that is returned.
+            <% end %>
             <code>photo[]</code>
           </p>
         </div>

--- a/views/form.erb
+++ b/views/form.erb
@@ -163,6 +163,14 @@
           <textarea class="form-control" rows="1" name="photo[]" id="photo"
             <% if @required.include?('photo') %>required<% end %>
             ><%= h @post.properties['photo'].join("\n") if @post.properties.key?('photo') %></textarea>
+
+            <% if @media %>
+              <script>document.write(`
+                <input type="file" id="photo_file" name="file" style="display: none;" />
+                <button type="button" class="btn btn-default" style="margin-top: 5px;" id="upload_photo" data-toggle="button" aria-pressed="false" autocomplete="off">Upload Photo</button>
+              `)</script>
+            <% end %>
+
           <p class="help-block">
             Enter the URL of the photo.
             You can enter multiple URLs separated by whitespace if your server supports this.


### PR DESCRIPTION
Closes #40.

This adds an upload button to the photo field. Then, it'll use the user's media endpoint to upload the photo and fill the field. Multiple pictures can be uploaded. Then they will be separated by `\n`.

The button only shows if the media endpoint exists and if JavaScript is enabled.

PS: never wrote Ruby before so I'm not sure if I handled the situation the best.