### PR TITLE
Fix default encoding

### DIFF
--- a/lib/micropublish/server.rb
+++ b/lib/micropublish/server.rb
@@ -375,8 +375,7 @@ module Micropublish
 
       def new_request
         require_session
-        Request.new(session[:micropub], session[:token],
-          session.key?('format') && session[:format] == :json)
+        Request.new(session[:micropub], session[:token], default_format == :json)
       end
 
       def format_form_encoded(content)


### PR DESCRIPTION
Closes https://github.com/barryf/micropublish/issues/107.

When `session.key?('format')` is not defined, the new request will not be set as `json` even if `default_format` assumes `json` by default.

Use `default_format` to decide if a request should use `json` or `form`.