### PR TITLE
Support IndieAuth Server Metadata for discovery

### DIFF
--- a/lib/micropublish/endpoints_finder.rb
+++ b/lib/micropublish/endpoints_finder.rb
@@ -10,23 +10,55 @@ module Micropublish
       @links = {}
     end
 
-    def get_url
+    def get_url(url)
       begin
-        response = HTTParty.get(@url)
+        response = HTTParty.get(url)
       rescue SocketError => e
-        raise AuthError.new("Client could not connect to \"#{@url}\".")
+        raise AuthError.new("Client could not connect to \"#{url}\".")
       end
       unless (200...300).include?(response.code)
-        raise AuthError.new("#{response.code} status returned from \"#{@url}\".")
+        raise AuthError.new("#{response.code} status returned from \"#{url}\".")
       end
       response
     end
 
     def find_links
-      response = get_url
+      response = get_url(@url)
+      find_metadata_links(response)
       find_header_links(response)
       find_body_links(response)
       @links unless @links.empty?
+    end
+
+    def find_metadata_url(response)
+      header_links = LinkHeader.parse(response.headers['Link'])
+      link = header_links.find_link(['rel', 'indieauth-metadata'])
+      if link.respond_to?('href') && !link.href.empty?
+        return URI.join(@url, link.href).to_s
+      end
+      html_links = Nokogiri::HTML(response.body).css('link')
+      html_links.each do |link|
+        if link[:rel] == 'indieauth-metadata' && !link[:href].empty?
+          return URI.join(@url, link[:href]).to_s
+        end
+      end
+      return
+    end
+
+    def find_metadata_links(doc_response)
+      return unless metadata_url = find_metadata_url(doc_response)
+      metadata_response = get_url(metadata_url)
+      begin
+        body = JSON.parse(metadata_response.body)
+      rescue JSON::ParserError
+        raise AuthError.new("Could not parse metadata JSON at #{metadata_url}.")
+      end
+      RELS.each do |rel|
+        if body.key?(rel) && !body[rel].empty? && !@links.key?(rel.to_sym)
+          absolute_url = URI.join(@url, body[rel]).to_s
+          @links[rel.to_sym] = absolute_url
+        end
+      end
     end
 
     def find_header_links(response)

--- a/spec/micropublish/endpoints_finder_spec.rb
+++ b/spec/micropublish/endpoints_finder_spec.rb
@@ -1,6 +1,5 @@
 describe Micropublish::EndpointsFinder do
 
-  URL = 'https://barryfrost.com'
   LINKS = {
     micropub: 'https://api.barryfrost.com/micropub',
     authorization_endpoint: 'https://indieauth.com/auth',
@@ -8,47 +7,99 @@ describe Micropublish::EndpointsFinder do
   }
 
   before do
-    stub_request(:get, 'https://barryfrost.com/').to_return(status: 200,
+    stub_request(:get, 'https://example-metadata-body.com/').to_return(status: 200,
       body: '
-        <link rel="micropub" href="https://api.barryfrost.com/micropub">
-        <link rel="authorization_endpoint" href="https://indieauth.com/auth">
-        <link rel="token_endpoint" href="https://tokens.indieauth.com/token">',
+        <link rel="indieauth-metadata" href="https://barryfrost.com/indieauth-metadata">
+      ',
+      headers: {}
+    )
+    stub_request(:get, 'https://example-metadata-headers.com/').to_return(status: 200,
+      body: '',
+      headers: {
+        "Link" => '<https://barryfrost.com/indieauth-metadata>; rel="indieauth-metadata"'
+      }
+    )
+    stub_request(:get, 'https://example-headers.com/').to_return(status: 200,
+      body: '',
       headers: {
         "Link" => '<https://api.barryfrost.com/micropub>; rel="micropub", <https://indieauth.com/auth>; rel="authorization_endpoint", <https://tokens.indieauth.com/token>; rel="token_endpoint"'
       }
     )
-    @endpoints_finder = Micropublish::EndpointsFinder.new(URL)
-    @response = @endpoints_finder.get_url
+    stub_request(:get, 'https://example-body.com/').to_return(status: 200,
+      body: '
+        <link rel="micropub" href="https://api.barryfrost.com/micropub">
+        <link rel="authorization_endpoint" href="https://indieauth.com/auth">
+        <link rel="token_endpoint" href="https://tokens.indieauth.com/token">
+      ',
+      headers: {}
+    )
+    stub_request(:get, 'https://barryfrost.com/indieauth-metadata').to_return(
+      status: 200,
+      body: {
+        authorization_endpoint: 'https://indieauth.com/auth',
+        token_endpoint: 'https://tokens.indieauth.com/token'
+      }.to_json
+    )
   end
 
   context "given a website url" do
 
     describe "#get_url" do
-      it "should retrieve a successful response from a valid url." do
-        expect(@response.code.to_i).to eql(200)
+      it "should retrieve a successful response from a valid url" do
+        url = 'https://example-body.com/'
+        endpoints_finder = Micropublish::EndpointsFinder.new(url)
+        response = endpoints_finder.get_url(url)
+        expect(response.code.to_i).to eql(200)
+      end
+    end
+
+    describe "#find_metadata_links" do
+      it "should return authorization_endpoint and token_endpoint from metadata link in body)" do
+        url = 'https://example-metadata-body.com/'
+        indieauth_links = LINKS.dup
+        indieauth_links.delete(:micropub)
+        endpoints_finder = Micropublish::EndpointsFinder.new(url)
+        response = endpoints_finder.get_url(url)
+        endpoints_finder.find_metadata_links(response)
+        expect(endpoints_finder.links).to eql(indieauth_links)
+      end
+      it "should return authorization_endpoint and token_endpoint from metadata link in headers" do
+        url = 'https://example-metadata-headers.com/'
+        indieauth_links = LINKS.dup
+        indieauth_links.delete(:micropub)
+        endpoints_finder = Micropublish::EndpointsFinder.new(url)
+        response = endpoints_finder.get_url(url)
+        endpoints_finder.find_metadata_links(response)
+        expect(endpoints_finder.links).to eql(indieauth_links)
       end
     end
 
     describe "#find_header_links" do
-      it "should return micropub, authorization_endpoint and token_endpoint from header." do
-        @endpoints_finder.find_header_links(@response)
-        links = @endpoints_finder.links
-        expect(links).to eql(LINKS)
+      it "should return micropub, authorization_endpoint and token_endpoint from header" do
+        url = 'https://example-headers.com/'
+        endpoints_finder = Micropublish::EndpointsFinder.new(url)
+        response = endpoints_finder.get_url(url)
+        endpoints_finder.find_header_links(response)
+        expect(endpoints_finder.links).to eql(LINKS)
       end
     end
 
     describe "#find_body_links" do
-      it "should return micropub, authorization_endpoint and token_endpoint from body." do
-        @endpoints_finder.find_body_links(@response)
-        links = @endpoints_finder.links
-        expect(links).to eql(LINKS)
+      it "should return micropub, authorization_endpoint and token_endpoint from body" do
+        url = 'https://example-body.com/'
+        endpoints_finder = Micropublish::EndpointsFinder.new(url)
+        response = endpoints_finder.get_url(url)
+        endpoints_finder.find_body_links(response)
+        expect(endpoints_finder.links).to eql(LINKS)
       end
     end
 
     describe "#validate" do
-      it "should ensure we have the three required endpoints." do
-        @endpoints_finder.find_header_links(@response)
-        expect { @endpoints_finder.validate! }.to_not raise_error
+      it "should ensure we have the three required endpoints" do
+        url = 'https://example-body.com/'
+        endpoints_finder = Micropublish::EndpointsFinder.new(url)
+        endpoints_finder.find_links
+        expect { endpoints_finder.validate! }.to_not raise_error
       end
     end
 

--- a/spec/micropublish/endpoints_finder_spec.rb
+++ b/spec/micropublish/endpoints_finder_spec.rb
@@ -40,13 +40,14 @@ describe Micropublish::EndpointsFinder do
         token_endpoint: 'https://tokens.indieauth.com/token'
       }.to_json
     )
+    stub_request(:get, 'https://example.com/').to_return(status: 200)
   end
 
   context "given a website url" do
 
     describe "#get_url" do
       it "should retrieve a successful response from a valid url" do
-        url = 'https://example-body.com/'
+        url = 'https://example.com/'
         endpoints_finder = Micropublish::EndpointsFinder.new(url)
         response = endpoints_finder.get_url(url)
         expect(response.code.to_i).to eql(200)


### PR DESCRIPTION
Extend endpoint discovery to allow servers to specify their [IndieAuth Server Metadata][1] endpoint as an alternative to the existing (legacy) headers/body methods.

If a server includes a `<link rel="indieauth-metadata" href="http://example.org/indieauth-metadata">` in its HTML or the equivalent `Link` in its header then Micropublish will fetch the resource, parse it as JSON and use its values for `authorization_endpoint` and `token_endpoint`.

Thanks to @gRegorLove for raising this.

Closes #118 

[1]: https://indieauth.spec.indieweb.org/#indieauth-server-metadata