### PR TITLE
feat: support editing photos

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.1] - 2025-02-11
+
+### Fixed
+
+- Fixed Post Type Discovery for photo posts by looking for `photo` property
+  when editing. Thanks to @hacdias for submitting the PR to fix this.
+
 ## [2.10.0] - 2025-02-09
 
 ### Added

--- a/lib/micropublish/post.rb
+++ b/lib/micropublish/post.rb
@@ -138,8 +138,8 @@ module Micropublish
       elsif @properties.key?('listen-of') &&
           Auth.valid_uri?(@properties['listen-of'][0])
         'listen'
-      elsif @properties.key?('photo') &&
-          @properties['photo'].is_a?(Array)
+      elsif @properties.key?('photo') && @properties['photo'].is_a?(Array) &&
+          @properties['photo'].size > 0
         'photo'
       elsif @properties.key?('name') && !@properties['name'].empty? &&
           !content_start_with_name?

--- a/lib/micropublish/post.rb
+++ b/lib/micropublish/post.rb
@@ -138,6 +138,9 @@ module Micropublish
       elsif @properties.key?('listen-of') &&
           Auth.valid_uri?(@properties['listen-of'][0])
         'listen'
+      elsif @properties.key?('photo') &&
+          @properties['photo'].is_a?(Array)
+        'photo'
       elsif @properties.key?('name') && !@properties['name'].empty? &&
           !content_start_with_name?
         'article'

--- a/lib/micropublish/version.rb
+++ b/lib/micropublish/version.rb
@@ -1,5 +1,5 @@
 module Micropublish
 
-  VERSION = "2.10.0"
+  VERSION = "2.10.1"
 
 end


### PR DESCRIPTION
Hi,

I noticed that when editing photos, it'd just automatically show up as an article/note depending on the existence of a title. My knowledge of Ruby is very limited, so I hope this is the right fix.

I didn't use `Auth.valid_uri` for all values of `photo`  in the case some people (like me) use some sort of identifier, or relative path to the post. 

