### PR TITLE
Add Docker support and more flexibility for dev settings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1
+
+# --> Stage 1: Runtime and Build Base Image
+ARG RUBY_VERSION=3.3
+FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
+WORKDIR /app
+SHELL [ "/bin/bash", "-c" ]
+
+# Install base packages
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y curl libjemalloc2 libvips && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Set production environment
+ENV BUNDLE_DEPLOYMENT="1" \
+    BUNDLE_PATH="/usr/local/bundle"
+
+#ENV BUNDLE_WITHOUT="development"
+
+
+# --> Stage 2: Build Environment
+FROM base AS build
+
+# Install packages needed to build gems
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential curl git pkg-config libyaml-dev && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Install application gems
+COPY Gemfile Gemfile.lock ./
+RUN bundle install && \
+    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*# Throw-away build stage to reduce size of final image
+
+COPY . .
+
+# --> Stage 3: Actual application deployment
+FROM base
+COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
+COPY --from=build /app /app
+
+RUN groupadd --system --gid 1000 app && \
+    useradd app --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
+    chown -R 1000:1000 .
+
+USER 1000:1000
+
+ENV RACK_ENV=production
+ENV REDIS_URL=redis://localhost:6379
+ENV FORCE_SSL=0
+
+CMD [ "bundle", "exec", "puma", "-b", "tcp://0.0.0.0:9292" ]

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '3.3.5'
+ruby '~> 3.3.0'
 
 gem 'sinatra'
 gem 'puma'

--- a/README.md
+++ b/README.md
@@ -140,6 +140,26 @@ If you host on your own server you will need to define the `COOKIE_SECRET`
 environment variable. You should use a long, secure, (ideally) random string
 to help secure data stored in the user's cookie.
 
+### Docker
+
+There is a [Dockerfile](./Dockerfile) and a [docker-compose](./docker-compose.yml) file.
+
+A local dev environment can be started like so:
+
+```sh
+COOKIE_SECRET=super_secret_and_super_unique_and_super_random_jkafhakdhaskhdakdncaskjhadljfaskdbnl \
+RACK_ENV=development \
+DEV_ME=http://myhostnameorlocalhost:4000 \
+DEV_MICROPUB=http://myhostnameorlocalhost:8000/micropub \
+DEV_SCOPE="create update delete undelete" \
+DEV_TOKEN=XXXXXXXXXXXXXXXX \
+docker compose up --build
+```
+
+- The `DEV_` envs are only used of `RACK_ENV=development`!
+- There is also the `FORCE_SSL` which will enforce redirection to `https://` if set to `1`.
+  Per default it is expected that a reverse proxy is taking care of that.
+
 ---
 
 ## Bookmarklets
@@ -165,7 +185,7 @@ will need to update if you are hosting Micropublish yourself.
 
 If you would like any help with setting up your Micropub endpoint, your best
 option is to
-[join the `#indieweb` channel][irc] on Freenode IRC.
+[join the `#indieweb` channel][irc] on libera.chat.
 
 For Micropublish specific help, [get in touch][bfcontact] and I'll be happy
 to help.

--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ DEV_TOKEN=XXXXXXXXXXXXXXXX \
 docker compose up --build
 ```
 
-- The `DEV_` envs are only used of `RACK_ENV=development`!
-- There is also the `FORCE_SSL` which will enforce redirection to `https://` if set to `1`.
-  Per default it is expected that a reverse proxy is taking care of that.
+- The `DEV_` envs are only used with `RACK_ENV=development`.
+- There is also a `FORCE_SSL` variable which will force redirection to `https://` if set to `1`.
+  By default it is expected that a reverse proxy is taking care of that.
 
 ---
 

--- a/app.json
+++ b/app.json
@@ -6,6 +6,10 @@
     "COOKIE_SECRET": {
       "description": "A long, secure, (ideally) random string used to secure data stored in the user's cookie.",
       "value": ""
+    },
+    "FORCE_SSL": {
+      "description": "Enable redirect from http:// to https:// - highly recommended if no reverse proxy is used which would take care of TLS termination",
+      "value": "1"
     }
   },
   "addons": [

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.0] - 2025-05-19
+
+### Added
+
+- Support has been added for running Micropublish and redis with Docker using 
+  the `docker-compose.yml` file. 
+- Optionally pass in `DEV_` environment variables if running in development
+  mode (see new section in `README.md` for details).
+- Thanks to @perryflynn for contributing these changes.
+
 ## [2.11.0] - 2025-02-22
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,12 +21,12 @@ services:
       - '9292:9292'
     environment:
       REDIS_URL: 'redis://redis:6379'
-      #COOKIE_SECRET: super_secret_and_super_unique_and_super_random_jkafhakdhaskhdakdncaskjhadljfaskdbnl
-      #RACK_ENV: development
-      #DEV_ME: http://${DEV_MACHINE:-localhost}:4000
-      #DEV_MICROPUB: http://${DEV_MACHINE:-localhost}:8000/micropub
-      #DEV_SCOPE: create update delete undelete
-      #DEV_TOKEN: ${DEV_TOKEN:-}
+      COOKIE_SECRET: ${COOKIE_SECRET:-super_secret_and_super_unique_and_super_random_jkafhakdhaskhdakdncaskjhadljfaskdbnl}
+      RACK_ENV: ${RACK_ENV:-production}
+      DEV_ME: ${DEV_ME:-http://localhost:4000}
+      DEV_MICROPUB: ${DEV_MICROPUB:-http://localhost:8000/micropub}
+      DEV_SCOPE: ${DEV_SCOPE:-create update delete undelete}
+      DEV_TOKEN: ${DEV_TOKEN:-}
     depends_on:
       - redis
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  redis:
+    restart: always
+    image: redis:7-alpine
+    networks:
+      internal_network:
+        aliases:
+          - redis
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+    volumes:
+      - micropublish-redis:/data
+
+  web:
+    build: .
+    restart: always
+    networks:
+      - external_network
+      - internal_network
+    ports:
+      - '9292:9292'
+    environment:
+      REDIS_URL: 'redis://redis:6379'
+      #COOKIE_SECRET: super_secret_and_super_unique_and_super_random_jkafhakdhaskhdakdncaskjhadljfaskdbnl
+      #RACK_ENV: development
+      #DEV_ME: http://${DEV_MACHINE:-localhost}:4000
+      #DEV_MICROPUB: http://${DEV_MACHINE:-localhost}:8000/micropub
+      #DEV_SCOPE: create update delete undelete
+      #DEV_TOKEN: ${DEV_TOKEN:-}
+    depends_on:
+      - redis
+
+networks:
+  external_network:
+  internal_network:
+    internal: true
+
+volumes:
+  micropublish-redis:

--- a/lib/micropublish/server.rb
+++ b/lib/micropublish/server.rb
@@ -8,7 +8,7 @@ module Micropublish
     configure do
       helpers Helpers
 
-      use Rack::SSL if settings.production?
+      use Rack::SSL if ENV['FORCE_SSL'] == '1'
 
       root_path = "#{File.dirname(__FILE__)}/../../"
       set :views, "#{root_path}views"
@@ -28,9 +28,10 @@ module Micropublish
 
     before do
       unless settings.production?
-        session[:me] = 'http://localhost:4444/'
-        session[:micropub] = 'http://localhost:3333/micropub'
-        session[:scope] = 'create update delete undelete'
+        session[:me] = ENV['DEV_ME'] || 'http://localhost:4444/'
+        session[:micropub] = ENV['DEV_MICROPUB'] || 'http://localhost:3333/micropub'
+        session[:scope] = ENV['DEV_SCOPE'] || 'create update delete undelete'
+        session[:token] = ENV['DEV_TOKEN'] || nil
       end
     end
 

--- a/lib/micropublish/version.rb
+++ b/lib/micropublish/version.rb
@@ -1,5 +1,5 @@
 module Micropublish
 
-  VERSION = "2.11.0"
+  VERSION = "2.12.0"
 
 end


### PR DESCRIPTION
This PR adds the following:

- Dockerfile and docker-compose.yml to run the App in Docker
- Change ruby requirement from `3.3.5` to `~> 3.3.0` to make it work with existing ruby docker images
- Extend readme
- Add `FORCE_SSL` env to allow SSL disabled in prod mode in Docker so that a reverse proxy can take care of SSL
- Add `DEV_*` envs to allow to change the endpoints and token in dev mode

Regards
Christian