### PR TITLE
feat: allow finding location without the auto-enable on

### DIFF
--- a/public/scripts/micropublish.js
+++ b/public/scripts/micropublish.js
@@ -69,10 +69,17 @@ $(function() {
 		})
 	}
 
-	$('#find_location').on('click', function() {
+	$('#find_location_checkin').on('click', function() {
 		getLocation(function (latitude, longitude) {
 			$("#latitude").val(latitude);
 			$("#longitude").val(longitude);
+		})
+		return false
+	});
+
+	$('#find_location').on('click', function() {
+		getLocation(function (latitude, longitude, accuracy) {
+			$('#location').val(`geo:${latitude},${longitude};u=${accuracy}`)
 		})
 		return false
 	});
@@ -84,6 +91,11 @@ $(function() {
 
 		function fillLocation() {
 			if (!getAutoLocation()) {
+				return
+			}
+
+			// Do not overwrite location if already set (e.g. editing existent post)
+			if ($('#location').val()) {
 				return
 			}
 

--- a/views/form.erb
+++ b/views/form.erb
@@ -246,7 +246,7 @@
               <% if @required.include?('checkin') %>required<% end %>
               value="<%= h @post.properties['checkin'][0]['properties']['longitude'][0] if @post.properties.key?('checkin') && @post.properties['checkin'].is_a?(Array) %>">
             <script>
-              document.write("&nbsp; <button type=\"button\" class=\"btn btn-default\" id=\"find_location\" data-toggle=\"button\" aria-pressed=\"false\" autocomplete=\"off\">Find</button>");
+              document.write("&nbsp; <button type=\"button\" class=\"btn btn-default\" id=\"find_location_checkin\" data-toggle=\"button\" aria-pressed=\"false\" autocomplete=\"off\">Find</button>");
             </script>
           </div>
           <p class="help-block">
@@ -380,15 +380,20 @@
             <% if @required.include?('location') %><span class="required" title="required">*</span><% end %>
           </label>
 
-          <input type="text" class="form-control"  name="location[]" id="location"
-            <% if @required.include?('location') %>required<% end %>
-            value="<%= h @post.properties['location'][0] if @post.properties.key?('location') %>">
+          <div class="form-inline">
+            <input type="text" class="form-control"  name="location[]" id="location"
+              <% if @required.include?('location') %>required<% end %>
+              value="<%= h @post.properties['location'][0] if @post.properties.key?('location') %>">
+            <script>
+              document.write("&nbsp; <button type=\"button\" class=\"btn btn-default\" id=\"find_location\" data-toggle=\"button\" aria-pressed=\"false\" autocomplete=\"off\">Find</button>");
+            </script>
+          </div>
 
-            <p class="help-block">
-              Enter a location for the post. If you check the "Auto-detect?" checkbox, a Geo URI
-              will be generated for you. The browser will remember your choice for the next time.
-              <code>location</code>
-            </p>
+          <p class="help-block">
+            Enter a location for the post. If you check the "Auto-detect?" checkbox, a Geo URI
+            will be generated for you. The browser will remember your choice for the next time.
+            <code>location</code>
+          </p>
         </div>
       <% end %>
 


### PR DESCRIPTION
Does two things:

- Adds a `Find` button next to the location field. This allows to automatically add a location without having the auto-detect on.
- If auto-detect is on, and we're editing a post that already contains a location, don't replace it by default. 

Maybe in the future, I'd like to add support for the `h-adr`, but that's a bit more involved.